### PR TITLE
Updating URL structures

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -53,7 +53,7 @@ include TripsHelper
 # Create all the proxy pages for locations we support
 departures.each do |departure|
   destinations.each do |destination|
-    proxy "/#{destination.slug}-from-#{departure.alpha2.downcase}.html", '/locations/template.html', locals: { departure: departure, destination: destination }, ignore: true
+    proxy "/#{destination.slug}/from/#{departure.slug}/index.html", '/locations/template.html', locals: { departure: departure, destination: destination }, ignore: true
   end
 end
 

--- a/config.rb
+++ b/config.rb
@@ -53,7 +53,7 @@ include TripsHelper
 # Create all the proxy pages for locations we support
 departures.each do |departure|
   destinations.each do |destination|
-    proxy "/#{destination.slug}/from/#{departure.slug}/index.html", '/locations/template.html', locals: { departure: departure, destination: destination }, ignore: true
+    proxy "/#{departure.slug}/#{destination.slug}/index.html", '/locations/template.html', locals: { departure: departure, destination: destination }, ignore: true
   end
 end
 

--- a/data/departures.yml
+++ b/data/departures.yml
@@ -1,8 +1,24 @@
-US: true
-GB: true
-CA: true
-FR: true
-DE: true
-NL: true
-AU: true
-KR: true
+US:
+  slug: usa
+  title: United States
+GB:
+  slug: uk
+  title: Great Britain
+CA:
+  slug: canada
+  title: Canada
+FR:
+  slug: france
+  title: France
+DE:
+  slug: germany
+  title: Germany
+NL:
+  slug: netherlands
+  title: Netherlands
+AU:
+  slug: australia
+  title: Australia
+KR:
+  slug: korea
+  title: Korea

--- a/helpers/trips_helper.rb
+++ b/helpers/trips_helper.rb
@@ -1,12 +1,12 @@
 module TripsHelper
   def departures
-    @departures ||= @app.data.departures.collect do |country_code, activated|
-      if activated
-        ISO3166::Country.new(country_code)
-      else
-        nil
-      end
-    end.compact
+    @departures ||= @app.data.departures.collect do |country_code, departure_data|
+      country_data = ISO3166::Country.new(country_code)
+      departure_data.merge({
+        currency: country_data.currency,
+        languages: country_data.languages,
+      })
+    end
   end
 
   def destinations

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -12,7 +12,7 @@ title: Upon Arrival
 </div>
 
 <div class="row">
-  <form id="locations-form" data-redirect-to="/#{wheregoing}/from/#{wherefrom}" action="#" method="post">
+  <form id="locations-form" data-redirect-to="/#{wherefrom}/#{wheregoing}" action="#" method="post">
 
     <label for="wherefrom">Where are you from?</label>
     <select name="Where are you from?" id="wherefrom">

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -12,13 +12,13 @@ title: Upon Arrival
 </div>
 
 <div class="row">
-  <form id="locations-form" data-redirect-to="/#{wheregoing}-from-#{wherefrom}" action="#" method="post">
+  <form id="locations-form" data-redirect-to="/#{wheregoing}/from/#{wherefrom}" action="#" method="post">
 
     <label for="wherefrom">Where are you from?</label>
     <select name="Where are you from?" id="wherefrom">
       <option value="">Where are you from?</option>
       <% departures.each do |departure| %>
-        <option value="<%= departure.alpha2.downcase %>"><%= departure.name %></option>
+        <option value="<%= departure.slug %>"><%= departure.title %></option>
       <% end %>
     </select>
 
@@ -26,7 +26,7 @@ title: Upon Arrival
     <select name="Where are you going?" id="wheregoing">
       <option value="">Where are you going?</option>
       <% destinations.each do |destination| %>
-        <option value="<%= destination[:slug] %>"><%= destination[:title] %></option>
+        <option value="<%= destination.slug %>"><%= destination.title %></option>
       <% end %>
     </select>
 


### PR DESCRIPTION
URLs now use the format: /london/from/uk
Names and slugs for departures are now controlled via data we set
instead of via a gem.

Closes #33

After merging this, make sure to run in the project folder:

```
rm -rf build && bundle exec middleman build && powder restart
```