### PR TITLE
Only invalidate HTML files on CDN

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -100,6 +100,9 @@ activate :cdn do |cdn|
     distribution_id: ENV['AWS_CLOUDFRONT_DISTRIBUTION_ID']
   }
 
+  # Only invalidate HTML files.
+  cdn.filter = /\.html/i
+
   # We only run this during the release task.
   cdn.after_build = false
 end


### PR DESCRIPTION
The .css/.js files are have fingerprints (the -ddhdd.css bit), so
invalidating them each deploy was unnecessary.